### PR TITLE
Expose sample knowledgegraph tool as a usable agent in main application

### DIFF
--- a/aya-chat-app.py
+++ b/aya-chat-app.py
@@ -18,8 +18,8 @@ ticket_search_tool = tool_ticket_query.TicketListingTool()
 import tools.tool_customer_consumption as tool_customer_consumption
 consumption_change_tool = tool_customer_consumption.ConsumptionMetricsTool()
 
-#import tools.knowledge_graph_accounts as knowledge_graph_accounts
-#account_info_tool = knowledge_graph_accounts.ToolKnowledgeGraphSearch()
+import tools.tool_accounts_kg as knowledge_graph_accounts
+account_info_tool = knowledge_graph_accounts.ToolAccountsKnowledgeGraph()
 
 import tools.tool_case_summarizer as tool_case_summarizer
 case_summarizer_tool = tool_case_summarizer.ToolCaseSummarizer()
@@ -41,7 +41,8 @@ agent_1 = Agent(
         """)), # This is the goal that the agent is trying to achieve
     tools=[ticket_search_tool,
            case_summarizer_tool,
-           consumption_change_tool],
+           consumption_change_tool,
+           account_info_tool],
     allow_delegation=False,
     max_iter=1,
     max_retry_limit=3,
@@ -180,7 +181,7 @@ AI Summarization Agent for support case details and comments.
                                
 Looks up recent trends in Customer Consumption.
 
-##### 👤 Account Personnel Registry Agent (Coming Soon)
+##### 👤 Account Personnel Registry Agent
                                
 Knowledge graph lookup of Customer Account Team personnel.
 </div>
@@ -209,6 +210,7 @@ with gr.Blocks(css=css, theme=theme, title="A.Y.A.") as demo:
                                           [1, {"text":"Show me the weekly average consumption changes for customers"}],
                                           [2, {"text":"Show me recent incident tickets from Evolve Pharma"}],
                                           [3, {"text":"Summarize support case ID 981492 in markdown"}],
+                                          [4, {"text":"Who are the support personnel responsible for Evolve Pharma?"}]
                                       ],
                                       inputs=[example_num, input], elem_id="examples_table", label="")
         with gr.Column(scale=15, elem_id="col"):

--- a/sample_external_applications/accounts_knowledge_graph_app/update-kg-endpoint-info.py
+++ b/sample_external_applications/accounts_knowledge_graph_app/update-kg-endpoint-info.py
@@ -23,5 +23,3 @@ if __name__ == "__main__":
         "KG_APP_SERVICE_IP": kg_address,
         "KG_APP_SERVICE_PORT": kg_port
     })
-    
-    print(updated_envs)

--- a/tools/tool_accounts_kg.py
+++ b/tools/tool_accounts_kg.py
@@ -1,0 +1,22 @@
+from crewai_tools import BaseTool
+import os
+import requests
+import json
+
+from sample_external_applications.accounts_knowledge_graph_app.client import KGClient
+
+kg = KGClient()
+
+class ToolAccountsKnowledgeGraph(BaseTool):
+    name: str = "AccountsKnowledgeGraphTool"
+    description: str = "Handles queries that can be answered by a knowledgegraph containing information about customer accounts and the field teams supporting them."
+
+    def _query_kg(self, question):
+        response = kg.query(question)
+        return json.dumps(response, indent=4)
+
+    def _run(self, request_id: str, question: str) -> str:
+        with open('/tmp/%s' % request_id, 'w') as tools_log:
+          tools_log.write('Accounts Knowledge Graph Query Agent')
+        response = self._query_kg(question)
+        return response


### PR DESCRIPTION
A neo4j server is launched inside of the project which is used to store some knowledgegraph data on the sample accounts.

This is paired with a small LLM-powered flow to translate a natural language question into Cypher queries.

![image](https://github.com/user-attachments/assets/4e90dd57-4f06-4b7d-9801-bdceb5d1ae3d)
